### PR TITLE
fix camera image type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Strava Home Assistant Integration
 
 NOTE: You MUST remove the HA_Strava integration from Home Assistant integration, HACS Integration, HACS Custom Repository and reboot HA before adding this.
+
 This is a fork or a fork :) codingcyclist/ha_strava -> madmic1314/ha_strava -> badguy99/ha_strava
 
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
-# Integration Abandonded - do not add to Home Assistant, it will fail
-With the last set of changes required, I've decided to no longer try and maintain integration. There will be no fixes or replies to issues - I leave this here in case anyone wants to fork it and take over.
-
-I used the original integration as I makde a gadget for my wife's running that sat on her desk at home as a bit of fun. She no longer works from home often, so this has fallen into disuse, especially with the drive to save as much electricity as possible, this now sits in a drawer.
-
-I'm a technologist by day, but never learnt to code beyond VBA and a bit of VB - was also pretty good at the OPL Language used on the Psion devices - so dropping into this integration at this level is too much a learning curve. Unfortunately, I have too much else to do outside of work to learn try and Python to the level of understanding required to carry this integration on. The rate of breaking changes that come from the rapid pace of HA means I simply can't keep up - I did try.
-
-Hopefully someone will pick this up and run with it (see what I did there?), else "My battery is low and it’s getting dark." -Opportunity Rover
-
-
 # Strava Home Assistant Integration
 
 NOTE: You MUST remove the HA_Strava integration from Home Assistant integration, HACS Integration, HACS Custom Repository and reboot HA before adding this.
+This is a fork or a fork :) codingcyclist/ha_strava -> madmic1314/ha_strava -> badguy99/ha_strava
+
 
 Custom Component to integrate Activity Data from Strava into Home Assistant.
-
-This is a fork from Codingcyclist <https://github.com/codingcyclist/ha_strava> in an attempt to keep the integration alive - I take no credit for his hard work. I'm not a coder and the best you'll get from me is copy + paste, but happy to accept contributions and help from the community.
 
 ## Features
 
@@ -148,8 +138,6 @@ views:
 ## Contributors
 
 * [@codingcyclist](https://github.com/codingcyclist)
+* [@madmic1314](https://github.com/madmic1314/)
 
 ## TODO
-
---- NONE PLANNED ---
-Learn how to code?

--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,
     EVENT_HOMEASSISTANT_START,
-    EVENT_TIME_CHANGED,
 )
 from homeassistant.helpers import (
     aiohttp_client,

--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from homeassistant.components.camera import Camera
 import requests
@@ -106,7 +107,9 @@ class UrlCam(Camera):
         )
         return False
 
-    def camera_image(self):
+    def camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
         """Return image response."""
         if len(self._urls) == self._url_index:
             _LOGGER.debug("No custom image urls....serving default image")

--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
+from datetime import timedelta
 import logging
 from homeassistant.components.camera import Camera
 import requests
 import os
 import pickle
-from homeassistant.components.local_file.camera import LocalFile
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 from .const import (
     DOMAIN,
     CONF_PHOTOS_ENTITY,
@@ -18,7 +19,6 @@ from .const import (
     CONFIG_URL_DUMP_FILENAME,
 )
 from hashlib import md5
-from homeassistant.const import EVENT_TIME_CHANGED
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,24 +37,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities([camera])
 
     def image_update_listener(event):
-        """listen for time update event (every second) and update images if appropriate"""
-        ha_strava_config_entries = hass.config_entries.async_entries(domain=DOMAIN)
+        """Update images when track time interval fires"""
+         camera.rotate_img()
 
-        if len(ha_strava_config_entries) != 1:
-            return -1
-
-        img_update_interval_seconds = int(
-            ha_strava_config_entries[0].options.get(
-                CONF_IMG_UPDATE_INTERVAL_SECONDS,
-                CONF_IMG_UPDATE_INTERVAL_SECONDS_DEFAULT,
-            )
+    ha_strava_config_entries = hass.config_entries.async_entries(domain=DOMAIN)
+    img_update_interval_seconds = int(
+        ha_strava_config_entries[0].options.get(
+            CONF_IMG_UPDATE_INTERVAL_SECONDS,
+            CONF_IMG_UPDATE_INTERVAL_SECONDS_DEFAULT,
         )
-
-        if event.data["now"].second % img_update_interval_seconds == 0:
-            camera.rotate_img()
+    )
 
     hass.data[DOMAIN]["remove_update_listener"].append(
-        hass.bus.async_listen(EVENT_TIME_CHANGED, image_update_listener)
+        async_track_time_interval(
+            hass,
+            image_update_listener,
+            timedelta(seconds=img_update_interval_seconds)
+        )
     )
 
     return

--- a/info.md
+++ b/info.md
@@ -1,12 +1,3 @@
-# Integration Abandonded - do not add to Home Assistant, it will fail
-With the last set of changes required, I've decided to no longer try and maintain integration. There will be no fixes or replies to issues - I leave this here in case anyone wants to fork it and take over.
-
-I used the original integration as I makde a gadget for my wife's running that sat on her desk at home as a bit of fun. She no longer works from home often, so this has fallen into disuse, especially with the drive to save as much electricity as possible, this now sits in a drawer.
-
-I'm a technologist by day, but never learnt to code beyond VBA and a bit of VB - was also pretty good at the OPL Language used on the Psion devices - so dropping into this integration at this level is too much a learning curve. Unfortunately, I have too much else to do outside of work to learn try and Python to the level of understanding required to carry this integration on. The rate of breaking changes that come from the rapid pace of HA means I simply can't keep up - I did try.
-
-Hopefully someone will pick this up and run with it (see what I did there?), else "My battery is low and it’s getting dark." -Opportunity Rover
-
 # Strava Home Assistant Integration
 Custom Component to integrate Activity Data from Strava into Home Assistant.
 
@@ -38,8 +29,8 @@ Since every Strava activity gets its own virtual device, you can use the underly
 The Strava Home Assistant Integration also creates a **device entity** for both **Year-to-Date and All-Time** summary statistics. Each of these virtual device entities exposes **nine sensor entities**:
 * Moving Time
 * Distance
-* Activity Count
+* Activity Cou
 ...for **Ride, Run, and Swim** activities
 
 ## Installation
-For much more detailed guidelines on how to configure Strava Home Assitant, check out the (README) https://github.com/madmic1314/ha_strava
+For much more detailed guidelines on how to configure Strava Home Assitant, check out the (README) https://github.com/badguy99/ha_strava

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
     "codeowners": [
-        "@madmic1314"
+        "@badguy99"
     ],
     "config_flow": true,
     "dependencies": [],
-    "documentation": "https://github.com/madmic1314/ha_strava",
+    "documentation": "https://github.com/badguy99/ha_strava",
     "domain": "ha_strava",
     "iot_class": "cloud_polling",
     "name": "HA Strava",
@@ -12,5 +12,5 @@
         "aiohttp>=3.6.1",
         "voluptuous>=0.11.7"
     ],
-    "version": "0.2.1"
+    "version": "2022.5.1"
 }


### PR DESCRIPTION
Fixes #9 

The base camera_image function (https://github.com/home-assistant/core/blame/dev/homeassistant/components/camera/__init__.py#L571) in home assistant had been updated, so this updates the ha_strava function to match